### PR TITLE
[codex] Refactor binary tree right side view

### DIFF
--- a/practice/leetcode/solutions_00000/solution_00199.py
+++ b/practice/leetcode/solutions_00000/solution_00199.py
@@ -3,7 +3,7 @@
 """LeetCode solution 00199."""
 
 import unittest
-from collections import defaultdict
+from collections import deque
 
 
 class TreeNode(object):
@@ -20,54 +20,24 @@ class Solution(object):
         :rtype: List[int]
         """
         if not root:
-            return root
-
-        s, res = [root], []
-
-        while s:
-            res.append(s[-1].val)
-            k = len(s)
-            for _ in range(k):
-                node = s.pop(0)
-                if node.left:
-                    s.append(node.left)
-                if node.right:
-                    s.append(node.right)
-
-        return res
-
-
-class Solution2(object):
-    def rightSideView(self, root):
-        """
-        :type root: TreeNode
-        :rtype: List[int]
-        """
-        if not root:
             return []
 
-        q = [(0, root)]
-        d = defaultdict(list)
-        max_level = 0
-
-        while q:
-            level, node = q[0]
-            max_level = max(max_level, level)
-            d[level].append(node.val)
-
-            if node.left:
-                q.append((level + 1, node.left))
-            if node.right:
-                q.append((level + 1, node.right))
-
-            q = q[1:]
-
+        queue = deque([root])
         ans = []
-        for level in range(max_level + 1):
-            ans.append(d[level][-1])
+
+        while queue:
+            level_size = len(queue)
+            for i in range(level_size):
+                node = queue.popleft()
+                if node.left:
+                    queue.append(node.left)
+                if node.right:
+                    queue.append(node.right)
+
+                if i == level_size - 1:
+                    ans.append(node.val)
 
         return ans
-
 
 class TestSolution(unittest.TestCase):
     def test_rightSideView(self):
@@ -78,10 +48,10 @@ class TestSolution(unittest.TestCase):
         root.right.right = TreeNode(4)
 
         solution = Solution()
-        solution2 = Solution2()
 
         self.assertListEqual(solution.rightSideView(root), [1, 3, 4])
-        self.assertListEqual(solution2.rightSideView(root), [1, 3, 4])
+
+        self.assertListEqual(solution.rightSideView(None), [])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Refactor LeetCode 00199 to keep a single BFS solution for binary tree right side view.

## Details

- Replace list-based queue operations with collections.deque.
- Remove the duplicate Solution2 implementation that did the same level-order traversal work.
- Return [] for an empty tree and cover that case in the unit test.

## Validation

- python3 practice/leetcode/solutions_00000/solution_00199.py
- Commit hook: pytest (805 passed) and pylint on changed Python files (10.00/10)